### PR TITLE
.envrc file for virtualenv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+[ -f .venv/bin/activate ] && source .venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Our Github Actions [build workflow](https://github.com/umts/embedded-departure-b
 4. Activate your Python virtual environment
    ```sh
    source .venv/bin/activate
+   # Or, if you're a direnv user, leave and come back
+   cd
+   cd -
    ```
 6. Install West
    ```sh


### PR DESCRIPTION
Easy-peasy. You don't get the `$PS1` addition (direnv doesn't allow setting `$PS1`), but you can add it to your prompt by interpolating `$VIRTUAL_ENV_PROMPT`.