### PR TITLE
Set `CONFIG_BOOT_SIGNATURE_KEY_FILE` conditionally

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.20.0)
 
-SET(mcuboot_CONFIG_BOOT_SIGNATURE_KEY_FILE "\"${CMAKE_CURRENT_SOURCE_DIR}/keys/private/boot-ecdsa-p256.pem\"")
-SET(mcuboot_CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256 "y")
+if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/keys/private/boot-ecdsa-p256.pem")
+  SET(mcuboot_CONFIG_BOOT_SIGNATURE_KEY_FILE "\"${CMAKE_CURRENT_SOURCE_DIR}/keys/private/boot-ecdsa-p256.pem\"")
+  SET(mcuboot_CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256 "y")
+endif()
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(embedded-departure-board)


### PR DESCRIPTION
Allow the default mcuboot key if the private key file isn't present.

Closes #27