### PR TITLE
Don't reset if light sensor is unreachable

### DIFF
--- a/app/boards/circuitdojo_feather_nrf9160_ns.overlay
+++ b/app/boards/circuitdojo_feather_nrf9160_ns.overlay
@@ -45,6 +45,7 @@
   };
 
   sen0562@23 {
+    status = "okay";
     compatible = "dfrobot,sen0562";
     reg = <0x23>;
   };

--- a/app/src/light_sensor.c
+++ b/app/src/light_sensor.c
@@ -7,24 +7,25 @@
 
 LOG_MODULE_REGISTER(light_sensor);
 
+#define I2C1 DT_NODELABEL(i2c1)
+
+#if DT_NODE_HAS_STATUS(I2C1, okay)
+const struct device *const i2c_dev = DEVICE_DT_GET(I2C1);
+#else
+#error "i2c1 node is disabled"
+#endif
+
 #define SEN_ADDR 0x23
 #define SEN_REG_LUX 0x10
-
-const struct device *i2c_dev = DEVICE_DT_GET(DT_NODELABEL(i2c1));
 
 int get_lux(void) {
   uint8_t lux[2] = {0, 0};
   int ret;
 
-  if (i2c_dev == NULL || !device_is_ready(i2c_dev)) {
-    LOG_ERR("Could not get I2C device");
-    return -1;
-  }
-
   ret = i2c_burst_read(i2c_dev, SEN_ADDR, SEN_REG_LUX, &lux[0], 2);
   if (ret) {
-    LOG_ERR("Unable get lux data. (err %i)\n", ret);
-    return -1;
+    LOG_WRN("Unable get lux data. Keeping PWM lights off. (err %i)", ret);
+    return 0xFF;
   }
 
   ret = ((uint16_t)lux[0] << 8) | (uint16_t)lux[1];


### PR DESCRIPTION
We don't want the who system to fail if the light sensor does, just turn the PWM lights off.